### PR TITLE
Add Apple code signing for macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,33 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      # macOS Code Signing Setup
+      - name: Import Apple Developer Certificate
+        if: matrix.os == 'macos-latest'
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          # Create temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PWD=$(openssl rand -base64 32)
+          
+          # Create keychain
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          
+          # Import certificate
+          echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
+          security import certificate.p12 -P "$MACOS_CERTIFICATE_PWD" -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          
+          # Add to search list
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/\"//g')
+          
+          # Clean up
+          rm certificate.p12
+      
       - name: Build and Publish
         run: |
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
@@ -42,6 +69,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   # Build-only job for PRs (no publishing)
   build-pr:

--- a/APPLE_SIGNING_SETUP.md
+++ b/APPLE_SIGNING_SETUP.md
@@ -1,0 +1,74 @@
+# Apple Code Signing Setup for GitHub Actions
+
+This document explains how to set up Apple code signing for the Time Buddy Electron app in GitHub Actions.
+
+## Converting Your Certificate
+
+If you have a `developerID_application.cer` file from Apple Developer Portal:
+
+1. **Import the certificate to Keychain Access**
+   ```bash
+   # Double-click the .cer file or use:
+   security import developerID_application.cer -k ~/Library/Keychains/login.keychain
+   ```
+
+2. **Export as .p12 from Keychain Access**
+   - Open Keychain Access
+   - Find your "Developer ID Application" certificate
+   - Right-click → Export
+   - Choose .p12 format
+   - Set a password (you'll need this for GitHub secrets)
+
+3. **Convert to base64 for GitHub**
+   ```bash
+   base64 -i certificate.p12 | pbcopy
+   ```
+
+## Required GitHub Secrets
+
+You need to configure the following secrets in your GitHub repository settings:
+
+1. **MACOS_CERTIFICATE** - Base64 encoded .p12 certificate file
+   - Use the base64 string from step 3 above
+   - Add the encoded string as this secret
+
+2. **MACOS_CERTIFICATE_PWD** - Password used when exporting the .p12 certificate
+
+3. **APPLE_ID** - Your Apple Developer account email address
+
+4. **APPLE_ID_PASSWORD** - App-specific password for your Apple ID
+   - Generate at: https://appleid.apple.com/account/manage
+   - Under "Sign-In and Security" → "App-Specific Passwords"
+
+5. **APPLE_TEAM_ID** - Your Apple Developer Team ID
+   - Found in your Apple Developer account under "Membership"
+
+6. **GH_TOKEN** - GitHub Personal Access Token (already configured)
+   - Needs `repo` scope for publishing releases
+
+## How It Works
+
+1. The GitHub Actions workflow imports your certificate into a temporary keychain
+2. electron-builder uses the certificate to sign the app during build
+3. The signed app is notarized with Apple (requires Apple ID credentials)
+4. The DMG is created with the signed and notarized app
+
+## Testing
+
+To test locally before pushing:
+```bash
+export CSC_LINK=$(base64 -i /path/to/certificate.p12)
+export CSC_KEY_PASSWORD="your-p12-password"
+export APPLE_ID="your-apple-id@email.com"
+export APPLE_ID_PASSWORD="your-app-specific-password"
+export APPLE_TEAM_ID="your-team-id"
+
+npm run build-mac
+```
+
+## Troubleshooting
+
+- If signing fails, check that your certificate hasn't expired
+- Ensure the certificate includes the private key when exporting from Keychain
+- App-specific passwords are different from your Apple ID password
+- The certificate must be a "Developer ID Application" certificate for distribution outside the App Store

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "time-buddy",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Your time series metric friend - Desktop IDE for executing InfluxQL and PromQL queries via Grafana API",
     "main": "main.js",
     "homepage": "./",
@@ -65,6 +65,11 @@
         ],
         "mac": {
             "category": "public.app-category.developer-tools",
+            "identity": null,
+            "hardenedRuntime": true,
+            "gatekeeperAssess": false,
+            "entitlements": "build/entitlements.mac.plist",
+            "entitlementsInherit": "build/entitlements.mac.plist",
             "target": [
                 {
                     "target": "dmg",


### PR DESCRIPTION
- Configure electron-builder for code signing with hardened runtime
- Add GitHub Actions workflow steps to import certificates
- Create entitlements file for macOS app permissions
- Document setup process for Apple Developer certificates
- Bump version to 0.3.1