### PR TITLE
Simplify notarization config and bump version to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "time-buddy",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "Your time series metric friend - Desktop IDE for executing InfluxQL and PromQL queries via Grafana API",
     "main": "main.js",
     "homepage": "./",
@@ -69,9 +69,7 @@
             "gatekeeperAssess": false,
             "entitlements": "build/entitlements.mac.plist",
             "entitlementsInherit": "build/entitlements.mac.plist",
-            "notarize": {
-                "teamId": "${env.APPLE_TEAM_ID}"
-            },
+            "notarize": true,
             "target": [
                 {
                     "target": "dmg",


### PR DESCRIPTION
- Use simple boolean for notarize instead of object with env var
- Electron-builder will use environment variables automatically